### PR TITLE
Resolve stale Hugging Face API issues

### DIFF
--- a/R/datasets_api.R
+++ b/R/datasets_api.R
@@ -9,6 +9,8 @@
 #' @returns Character string with the config name.
 #' @keywords internal
 hf_detect_config <- function(dataset, split, token = NULL) {
+  split <- hf_split_base(split)
+
   req <- httr2::request("https://datasets-server.huggingface.co/splits") |>
     httr2::req_url_query(dataset = dataset)
 
@@ -58,6 +60,106 @@ hf_detect_config <- function(dataset, split, token = NULL) {
 
   # If no match for the split, use the first available config
   result$splits[[1]]$config
+}
+
+
+hf_split_base <- function(split) {
+  sub("\\[.*$", "", split)
+}
+
+
+hf_split_num_rows <- function(dataset, config, split, token = NULL) {
+  req <- httr2::request("https://datasets-server.huggingface.co/size") |>
+    httr2::req_url_query(dataset = dataset, config = config)
+
+  if (!is.null(token)) {
+    req <- httr2::req_auth_bearer_token(req, token)
+  }
+
+  resp <- req |>
+    httr2::req_error(body = function(resp) {
+      paste0("Failed to get split size for dataset '", dataset, "'")
+    }) |>
+    httr2::req_perform()
+
+  result <- httr2::resp_body_json(resp)
+  matching <- purrr::keep(result$size$splits %||% list(), function(s) s$split == split)
+
+  if (length(matching) == 0 || is.null(matching[[1]]$num_rows)) {
+    stop(
+      paste0("Could not determine row count for split '", split,
+             "'. Use a numeric slice or explicit limit/offset instead."),
+      call. = FALSE
+    )
+  }
+
+  matching[[1]]$num_rows
+}
+
+
+hf_parse_split_bound <- function(bound, num_rows, default, is_end = FALSE) {
+  if (identical(bound, "")) {
+    return(default)
+  }
+
+  if (grepl("%$", bound)) {
+    pct <- suppressWarnings(as.numeric(sub("%$", "", bound)))
+    if (is.na(pct) || pct < 0 || pct > 100) {
+      stop("Split percentage bounds must be between 0% and 100%.", call. = FALSE)
+    }
+
+    value <- pct / 100 * num_rows
+    return(if (is_end) ceiling(value) else floor(value))
+  }
+
+  value <- suppressWarnings(as.integer(bound))
+  if (is.na(value) || value < 0) {
+    stop("Split bounds must be non-negative integers or percentages.", call. = FALSE)
+  }
+
+  value
+}
+
+
+hf_parse_split <- function(split, dataset, config, token = NULL) {
+  if (!grepl("\\[|\\]", split)) {
+    return(list(split = split, offset = 0L, limit = Inf))
+  }
+
+  has_valid_brackets <- grepl("^[^[]+\\[", split) && grepl("\\]$", split)
+  bounds <- if (has_valid_brackets) {
+    sub("^[^[]+\\[", "", sub("\\]$", "", split))
+  } else {
+    ""
+  }
+  bounds <- strsplit(bounds, ":", fixed = TRUE)[[1]]
+
+  if (!has_valid_brackets || length(bounds) != 2) {
+    stop(
+      "Split slices must use the form 'split[start:end]', e.g. 'train[:10%]' or 'train[100:200]'.",
+      call. = FALSE
+    )
+  }
+
+  base_split <- sub("\\[.*$", "", split)
+  start_bound <- bounds[[1]]
+  end_bound <- bounds[[2]]
+  needs_num_rows <- grepl("%$", start_bound) || grepl("%$", end_bound) || identical(end_bound, "")
+  num_rows <- if (needs_num_rows) hf_split_num_rows(dataset, config, base_split, token) else NA_integer_
+
+  start <- hf_parse_split_bound(start_bound, num_rows, default = 0L, is_end = FALSE)
+  end <- hf_parse_split_bound(end_bound, num_rows, default = num_rows, is_end = TRUE)
+
+  if (!is.na(num_rows)) {
+    start <- min(start, num_rows)
+    end <- min(end, num_rows)
+  }
+
+  if (end < start) {
+    stop("Split slice end must be greater than or equal to start.", call. = FALSE)
+  }
+
+  list(split = base_split, offset = start, limit = end - start)
 }
 
 
@@ -111,7 +213,9 @@ hf_resolve_dataset <- function(dataset, token = NULL) {
 #'
 #' @param dataset Character string. Dataset name (e.g., "imdb", "squad").
 #' @param split Character string. Dataset split: "train", "test", "validation", etc.
-#'   Default: "train".
+#'   Supports Hugging Face slice syntax such as `"train[100:200]"`.
+#'   Percentage slices like `"train[:10\\%]"` are also supported. Default:
+#'   "train".
 #' @param config Character string or NULL. Dataset configuration/subset name.
 #'   If NULL (default), auto-detected from the dataset's available configs.
 #' @param limit Integer. Maximum number of rows to fetch. Default: 1000.
@@ -129,6 +233,9 @@ hf_resolve_dataset <- function(dataset, token = NULL) {
 #'
 #' # Load test set
 #' imdb_test <- hf_load_dataset("imdb", split = "test", limit = 500)
+#'
+#' # Load a slice of a split
+#' imdb_sample <- hf_load_dataset("imdb", split = "train[100:200]", limit = Inf)
 #' }
 hf_load_dataset <- function(dataset,
                             split = "train",
@@ -147,9 +254,18 @@ hf_load_dataset <- function(dataset,
     }
   }
 
+  split_query <- hf_split_base(split)
+
   # Auto-detect config if not provided
   if (is.null(config)) {
-    config <- hf_detect_config(dataset, split, token)
+    config <- hf_detect_config(dataset, split_query, token)
+  }
+
+  split_info <- hf_parse_split(split, dataset, config, token)
+  split_query <- split_info$split
+  offset <- offset + split_info$offset
+  if (is.finite(split_info$limit)) {
+    limit <- min(limit, split_info$limit)
   }
 
   # Build API URL with all required parameters
@@ -157,7 +273,7 @@ hf_load_dataset <- function(dataset,
     "https://datasets-server.huggingface.co/rows?dataset=",
     utils::URLencode(dataset, reserved = TRUE),
     "&config=", utils::URLencode(config, reserved = TRUE),
-    "&split=", utils::URLencode(split, reserved = TRUE)
+    "&split=", utils::URLencode(split_query, reserved = TRUE)
   )
   
   # Fetch data in batches if limit > 100

--- a/README.Rmd
+++ b/README.Rmd
@@ -181,6 +181,9 @@ hf_search_models(task = "text-classification", limit = 10)
 
 # Load datasets into tibbles (no Python needed)
 imdb <- hf_load_dataset("imdb", split = "train", limit = 1000)
+
+# Hugging Face split slices work too
+imdb_sample <- hf_load_dataset("imdb", split = "train[:10%]", limit = 1000)
 ```
 
 ## Learn More

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ hf_search_models(task = "text-classification", limit = 10)
 
 # Load datasets into tibbles (no Python needed)
 imdb <- hf_load_dataset("imdb", split = "train", limit = 1000)
+
+# Hugging Face split slices work too
+imdb_sample <- hf_load_dataset("imdb", split = "train[:10%]", limit = 1000)
 ```
 
 ## Learn More

--- a/man/hf_load_dataset.Rd
+++ b/man/hf_load_dataset.Rd
@@ -17,7 +17,9 @@ hf_load_dataset(
 \item{dataset}{Character string. Dataset name (e.g., "imdb", "squad").}
 
 \item{split}{Character string. Dataset split: "train", "test", "validation", etc.
-Default: "train".}
+Supports Hugging Face slice syntax such as `"train[100:200]"`.
+Percentage slices like `"train[:10\\%]"` are also supported. Default:
+"train".}
 
 \item{config}{Character string or NULL. Dataset configuration/subset name.
 If NULL (default), auto-detected from the dataset's available configs.}
@@ -44,5 +46,8 @@ imdb <- hf_load_dataset("imdb", split = "train", limit = 1000)
 
 # Load test set
 imdb_test <- hf_load_dataset("imdb", split = "test", limit = 500)
+
+# Load a slice of a split
+imdb_sample <- hf_load_dataset("imdb", split = "train[100:200]", limit = Inf)
 }
 }

--- a/tests/testthat/test-datasets.R
+++ b/tests/testthat/test-datasets.R
@@ -28,6 +28,32 @@ test_that("hf_load_dataset respects config parameter", {
   expect_equal(nrow(result), 2)
 })
 
+test_that("hf_load_dataset supports numeric split slices", {
+  skip_on_cran()
+  result <- hf_load_dataset("stanfordnlp/imdb", split = "train[10:12]",
+                            config = "plain_text", limit = Inf)
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 2)
+  expect_equal(unique(result$.split), "train[10:12]")
+})
+
+test_that("hf_load_dataset supports percentage split slices", {
+  skip_on_cran()
+  result <- hf_load_dataset("stanfordnlp/imdb", split = "train[:1%]",
+                            config = "plain_text", limit = 2)
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 2)
+  expect_equal(unique(result$.split), "train[:1%]")
+})
+
+test_that("hf_load_dataset works for datasets without label columns", {
+  skip_on_cran()
+  result <- hf_load_dataset("openai/gdpval", split = "train", limit = 2)
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 2)
+  expect_false("label" %in% names(result))
+})
+
 test_that("hf_load_dataset errors on non-existent dataset", {
   skip_on_cran()
   expect_error(hf_load_dataset("this-dataset-does-not-exist-xyz123"))

--- a/vignettes/hub-datasets-and-modeling.Rmd
+++ b/vignettes/hub-datasets-and-modeling.Rmd
@@ -197,6 +197,18 @@ train <- hf_load_dataset("imdb", split = "train", limit = 500)
 test <- hf_load_dataset("imdb", split = "test", limit = 500)
 ```
 
+`split` also supports Hugging Face slice syntax. This is useful when you want
+the same subset notation used by the Python `datasets` package, while still
+loading through the API-first R interface.
+
+```{r}
+# First 10% of the train split, capped by the package-level limit
+train_sample <- hf_load_dataset("imdb", split = "train[:10%]", limit = 500)
+
+# Rows 100 through 199 from the train split
+train_window <- hf_load_dataset("imdb", split = "train[100:200]", limit = Inf)
+```
+
 ### Pagination for Large Datasets
 
 Use `offset` to paginate through large datasets in batches.


### PR DESCRIPTION
## Summary
- Supports Hugging Face split-slice syntax in `hf_load_dataset()` for API-backed dataset loading, including numeric windows like `train[100:200]` and percentage slices like `train[:10%]`.
- Keeps the returned `.split` value aligned with the user-supplied split expression while translating to rows API `split`/`offset`/`length` under the hood.
- Documents API-first dataset loading and split slices in roxygen/Rd, README, and the Hub datasets vignette.
- Adds regression coverage for split slices and datasets that do not have a `label` column.

## Issue resolution
- Closes #51: API-first install/use no longer requires miniconda or local model loading by default.
- Closes #47: `hf_search_models()` now uses the Hub HTTP API and returns a tibble, avoiding the old reticulate iterator failure.
- Closes #45: API dataset loading no longer defaults to labels or requires a `label` column.
- Closes #43: `hf_load_dataset()` now supports Hugging Face split-slice syntax.
- Closes #39: old label/list handling concerns are obsolete for API-first dataset rows; list-valued columns are returned as-is for user-side tidying.
- Closes #37: Hub, inference, chat/generation, embeddings, and dataset workflows are now covered by package vignettes.
- Closes #25: old first-run local Python dataset loading issue is obsolete because default dataset loading uses the Datasets Server API.

## Validation
- `$env:NOT_CRAN='true'; $env:LC_CTYPE=$null; Rscript -e "pkgload::load_all(); testthat::test_file('tests/testthat/test-datasets.R'); testthat::test_file('tests/testthat/test-hub.R')"` passes.
- `$env:LC_CTYPE=$null; R.exe CMD build --no-manual --no-build-vignettes .; R.exe CMD check --no-manual --no-build-vignettes huggingfaceR_2.0.0.tar.gz` passes with `Status: OK`.